### PR TITLE
Propagate change event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/backbone-documentmodel.js
+++ b/backbone-documentmodel.js
@@ -253,18 +253,16 @@
 
         //console.log('DocumentEvent:event:this (' + this.name + ') [' + (this instanceof Backbone.Model ? 'M' : 'C') + ']:' + eventName);
 
-        if (eventName === 'change') {
-            return;
+        if (eventName !== 'change') {
+          // Only trigger events on Models, Collections automatically replicate Child Model events.
+          eventAttrs.unshift(this.name);
+
+          var event = _.reduce(eventAttrs, function (memo, val) {
+              return memo + '.' + val;
+          });
+
+          args[0] = eventType + ':' + event;
         }
-
-        // Only trigger events on Models, Collections automatically replicate Child Model events.
-        eventAttrs.unshift(this.name);
-
-        var event = _.reduce(eventAttrs, function (memo, val) {
-            return memo + '.' + val;
-        });
-
-        args[0] = eventType + ':' + event;
 
         //console.log('DocumentEvent:trigger:this (' + this.name + ') [' + (this instanceof Backbone.Model ? 'M' : 'C') + ']:parent (' + (this.parent.name || (this.parent.collection ? this.parent.collection.name : 'undefined')) + ') [' + (this.parent instanceof Backbone.Model ? 'M' : 'C') + ']:' + args[0]);
         this.parent.trigger.apply(this.parent, args);


### PR DESCRIPTION
Something like this is what I was referring to in #8.  I tried this out and it is extremely handy for doing things like implementing an "edited" icon on screen for modified but unsaved items.

I wasn't able to run the tests or add a new one because `npm install` on OS X seems to hang when downloading phantomjs.  The CPU hits 100% and doesn't stop.
